### PR TITLE
Add delay to response calls

### DIFF
--- a/test/test_basic_responses.py
+++ b/test/test_basic_responses.py
@@ -1,5 +1,7 @@
+import time
+
 import requests
-from mockserver import request, response
+from mockserver import request, response, milliseconds
 from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 
@@ -30,3 +32,25 @@ class TestBasicResponses(MockServerClientTestCase):
 
         result = requests.get(MOCK_SERVER_URL)
         self.assertEqual(result.headers["i-like"], "i-like")
+
+    def test_delay_response(self):
+        self.client.stub(
+            request(),
+            response(delay=1)
+        )
+
+        start = time.time()
+        requests.get(MOCK_SERVER_URL)
+        elapsed = time.time() - start
+        self.assertGreater(elapsed, 1)
+
+    def test_delay_response_with_special_unit(self):
+        self.client.stub(
+            request(),
+            response(delay=milliseconds(500))
+        )
+
+        start = time.time()
+        requests.get(MOCK_SERVER_URL)
+        elapsed = time.time() - start
+        self.assertGreater(elapsed, 0.5)

--- a/test/test_delays.py
+++ b/test/test_delays.py
@@ -1,0 +1,38 @@
+import unittest
+
+from mockserver import _to_delay, seconds, milliseconds, microseconds, nanoseconds, minutes, \
+    hours, days
+
+
+class TestJsonResponse(unittest.TestCase):
+    def test_default_delay_is_seconds(self):
+        payload = _to_delay(10)
+        self.assertEqual(payload, {"timeUnit": "SECONDS", "value": 10})
+
+    def test_seconds(self):
+        payload = _to_delay(seconds(10))
+        self.assertEqual(payload, {"timeUnit": "SECONDS", "value": 10})
+
+    def test_milliseconds(self):
+        payload = _to_delay(milliseconds(10))
+        self.assertEqual(payload, {"timeUnit": "MILLISECONDS", "value": 10})
+
+    def test_microseconds(self):
+        payload = _to_delay(microseconds(10))
+        self.assertEqual(payload, {"timeUnit": "MICROSECONDS", "value": 10})
+
+    def test_nanoseconds(self):
+        payload = _to_delay(nanoseconds(10))
+        self.assertEqual(payload, {"timeUnit": "NANOSECONDS", "value": 10})
+
+    def test_minutes(self):
+        payload = _to_delay(minutes(10))
+        self.assertEqual(payload, {"timeUnit": "MINUTES", "value": 10})
+
+    def test_hours(self):
+        payload = _to_delay(hours(10))
+        self.assertEqual(payload, {"timeUnit": "HOURS", "value": 10})
+
+    def test_days(self):
+        payload = _to_delay(days(10))
+        self.assertEqual(payload, {"timeUnit": "DAYS", "value": 10})


### PR DESCRIPTION
The default is in SECONDS but other units are available, units were
based on https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/TimeUnit.html.

json_response now takes any arguments leaving only the relevant ones in
this function, since the real response is close it shouldn't be too hard
to figure out what the kwargs are.