### PR TITLE
Add verify method now we can verify single request

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ client.stub(
 
 (For when calling another component *IS* what you are testing)
 
-Using the `expect` will remember the request and verify it when `verify` is called.
+Using the `expect` will remember the request and verify it when `verify_expectations` is called.
 
 ```
 import json
@@ -80,7 +80,7 @@ client.expect(
     times(1)
 )
 
-client.verify()  # AssertionError !
+client.verify_expectations()  # AssertionError !
 ```
 
 * The `times(N)` parameter is mandatory for expect
@@ -161,6 +161,18 @@ client.expect(
 ```
 I.e. this will match `{"key": "value"}` or `{"key": "value", "another": "key"}`
 
+### Verifying request
+
+```
+from mockserver import MockServerClient, request, times
+
+client = MockServerClient("http://localhost:1080")
+client.verify(
+    request(path="/some_path", querystring({"key": "value"})),
+    times(1)
+)
+```
+Verify will check request on MockServer and raise AssertionError if request not found.
 
 ## More documentation
 
@@ -182,7 +194,7 @@ class ServerMockingTestBase(...):
     def tearDown(self):
         super(ServerMockingTestBase, self).tearDown()
         
-        self.client.verify()
+        self.client.verify_expectations()
 ```
 
 # Troubleshooting

--- a/mockserver/__init__.py
+++ b/mockserver/__init__.py
@@ -27,13 +27,16 @@ class MockServerClient:
         self.stub(request, response, timing, time_to_live)
         self.expectations.append((request, timing))
 
-    def verify(self):
+    def verify(self, request, timing=1):
+        result = self._call("verify", json.dumps({
+            "httpRequest": request,
+            "times": timing.for_verification()
+        }))
+        assert result.status_code == 202, result.content.decode("UTF-8").replace("\n", "\r\n")
+
+    def verify_expectations(self):
         for req, timing in self.expectations:
-            result = self._call("verify", json.dumps({
-                "httpRequest": req,
-                "times": timing.for_verification()
-            }))
-            assert result.status_code == 202, result.content.decode('UTF-8').replace('\n', '\r\n')
+            self.verify(req, timing)
 
 
 def request(method=None, path=None, querystring=None, body=None, headers=None, cookies=None):

--- a/mockserver/__init__.py
+++ b/mockserver/__init__.py
@@ -27,7 +27,7 @@ class MockServerClient:
         self.stub(request, response, timing, time_to_live)
         self.expectations.append((request, timing))
 
-    def verify(self, request, timing=1):
+    def verify(self, request, timing):
         result = self._call("verify", json.dumps({
             "httpRequest": request,
             "times": timing.for_verification()

--- a/mockserver/__init__.py
+++ b/mockserver/__init__.py
@@ -8,8 +8,8 @@ class MockServerClient:
         self.base_url = base_url
         self.expectations = []
 
-    def _call(self, command, data=None):
-        return requests.put("{}/{}".format(self.base_url, command), data=data)
+    def _call(self, command, data=None, **kwargs):
+        return requests.put("{}/{}".format(self.base_url, command), data=data, **kwargs)
 
     def reset(self):
         self.expectations = []
@@ -37,6 +37,15 @@ class MockServerClient:
     def verify_expectations(self):
         for req, timing in self.expectations:
             self.verify(req, timing)
+
+    def retrieve(self, type="REQUESTS", request=None):
+        try:
+            return self._call("retrieve",
+                              data=request and json.dumps(request) or None,
+                              params={"type": type, "format": "json"}
+                              ).json()
+        except ValueError:
+            return {}
 
 
 def request(method=None, path=None, querystring=None, body=None, headers=None, cookies=None):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -11,3 +11,4 @@ class MockServerClientTestCase(unittest.TestCase):
     def setUp(self):
         self.client = MockServerClient(MOCK_SERVER_URL)
         self.client.reset()
+        assert not self.client.retrieve(type="RECORDED_EXPECTATIONS")

--- a/test/test_basic_expectations.py
+++ b/test/test_basic_expectations.py
@@ -4,16 +4,6 @@ from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 
 class TestBasicExpectations(MockServerClientTestCase):
-    def test_expect_once_not_called_fails(self):
-        self.client.expect(
-            request(),
-            response(),
-            times(1)
-        )
-
-        with self.assertRaises(AssertionError):
-            self.client.verify_expectations()
-
     def test_expect_once_called_twice_fails(self):
         self.client.expect(
             request(),
@@ -26,15 +16,6 @@ class TestBasicExpectations(MockServerClientTestCase):
 
         result = requests.get(MOCK_SERVER_URL + "/path")
         self.assertEqual(result.status_code, 404)
-
-    def test_expect_never(self):
-        self.client.expect(
-            request(),
-            response(),
-            times(0)
-        )
-
-        self.client.verify_expectations()
 
     def test_reset_should_clear_expectations(self):
         self.client.expect(

--- a/test/test_basic_expectations.py
+++ b/test/test_basic_expectations.py
@@ -4,6 +4,16 @@ from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 
 class TestBasicExpectations(MockServerClientTestCase):
+    def test_expect_once_not_called_fails(self):
+        self.client.expect(
+            request(),
+            response(),
+            times(1)
+        )
+
+        with self.assertRaises(AssertionError):
+            self.client.verify_expectations()
+
     def test_expect_once_called_twice_fails(self):
         self.client.expect(
             request(),
@@ -16,6 +26,15 @@ class TestBasicExpectations(MockServerClientTestCase):
 
         result = requests.get(MOCK_SERVER_URL + "/path")
         self.assertEqual(result.status_code, 404)
+
+    def test_expect_never(self):
+        self.client.expect(
+            request(),
+            response(),
+            times(0)
+        )
+
+        self.client.verify_expectations()
 
     def test_reset_should_clear_expectations(self):
         self.client.expect(

--- a/test/test_basic_expectations.py
+++ b/test/test_basic_expectations.py
@@ -12,7 +12,7 @@ class TestBasicExpectations(MockServerClientTestCase):
         )
 
         with self.assertRaises(AssertionError):
-            self.client.verify()
+            self.client.verify_expectations()
 
     def test_expect_once_called_twice_fails(self):
         self.client.expect(
@@ -34,7 +34,7 @@ class TestBasicExpectations(MockServerClientTestCase):
             times(0)
         )
 
-        self.client.verify()
+        self.client.verify_expectations()
 
     def test_reset_should_clear_expectations(self):
         self.client.expect(
@@ -44,7 +44,7 @@ class TestBasicExpectations(MockServerClientTestCase):
         )
 
         self.client.reset()
-        self.client.verify()
+        self.client.verify_expectations()
 
     def test_expect_with_ttl(self):
         self.client.expect(

--- a/test/test_basic_verifying.py
+++ b/test/test_basic_verifying.py
@@ -1,0 +1,21 @@
+import requests
+from mockserver import request, response, times
+from test import MOCK_SERVER_URL, MockServerClientTestCase
+
+
+class TestBasicVerifying(MockServerClientTestCase):
+    def test_verify_request_recived_once(self):
+        requests.get(MOCK_SERVER_URL)
+        self.client.verify(request(), times(1))
+
+    def test_verify_request_never_recived(self):
+        self.client.verify(request(), times(0))
+
+    def test_verify_request_not_recived_fail(self):
+        with self.assertRaises(AssertionError):
+            self.client.verify(request(), times(1))
+
+    def test_verify_all_expectations(self):
+        self.client.expect(request(), response(), times(1))
+        requests.get(MOCK_SERVER_URL)
+        self.client.verify_expectations()

--- a/test/test_basic_verifying.py
+++ b/test/test_basic_verifying.py
@@ -4,14 +4,14 @@ from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 
 class TestBasicVerifying(MockServerClientTestCase):
-    def test_verify_request_recived_once(self):
+    def test_verify_request_received_once(self):
         requests.get(MOCK_SERVER_URL)
         self.client.verify(request(), times(1))
 
-    def test_verify_request_never_recived(self):
+    def test_verify_request_never_received(self):
         self.client.verify(request(), times(0))
 
-    def test_verify_request_not_recived_fail(self):
+    def test_verify_request_not_received_fail(self):
         with self.assertRaises(AssertionError):
             self.client.verify(request(), times(1))
 

--- a/test/test_basic_verifying.py
+++ b/test/test_basic_verifying.py
@@ -1,4 +1,5 @@
 import requests
+from retry.api import retry_call
 from mockserver import request, response, times
 from test import MOCK_SERVER_URL, MockServerClientTestCase
 
@@ -6,7 +7,7 @@ from test import MOCK_SERVER_URL, MockServerClientTestCase
 class TestBasicVerifying(MockServerClientTestCase):
     def test_verify_request_received_once(self):
         requests.get(MOCK_SERVER_URL)
-        self.client.verify(request(), times(1))
+        retry_call(self.client.verify, fargs=(request(), times(1)), tries=10, delay=0.1)
 
     def test_verify_request_never_received(self):
         self.client.verify(request(), times(0))
@@ -18,4 +19,4 @@ class TestBasicVerifying(MockServerClientTestCase):
     def test_verify_all_expectations(self):
         self.client.expect(request(), response(), times(1))
         requests.get(MOCK_SERVER_URL)
-        self.client.verify_expectations()
+        retry_call(self.client.verify_expectations, tries=10, delay=0.1)

--- a/test/test_retrieve.py
+++ b/test/test_retrieve.py
@@ -1,0 +1,34 @@
+import requests
+from retry.api import retry_call
+from mockserver import request, response
+from test import MOCK_SERVER_URL, MockServerClientTestCase
+
+
+class TestRetrieve(MockServerClientTestCase):
+    def test_retrieve_expectations(self):
+        self.client.stub(
+            request(),
+            response()
+        )
+        requests.get(MOCK_SERVER_URL)
+        assert retry_call(self.client.retrieve,
+                          fkwargs=({"type": "RECORDED_EXPECTATIONS"}),
+                          tries=10, delay=0.3)
+
+    def test_retrieve_expectations_with_request(self):
+        path = "/test_path"
+        self.client.stub(request(path=path), response())
+        requests.get(MOCK_SERVER_URL + path)
+        assert retry_call(self.client.retrieve,
+                          fkwargs=({"type": "RECORDED_EXPECTATIONS", "request": request(path=path)}),
+                          tries=10, delay=0.3)
+
+    def test_retrieve_requests(self):
+        requests.get(MOCK_SERVER_URL)
+        assert retry_call(self.client.retrieve, fargs=("REQUESTS",), tries=10, delay=0.3)
+
+    def test_retrieve_requests_with_request(self):
+        requests.get(MOCK_SERVER_URL + '/path')
+        assert retry_call(self.client.retrieve,
+                          fkwargs=({"type": "REQUESTS", "request": request(path='/path')}),
+                          tries=10, delay=0.3)


### PR DESCRIPTION
With this feature, we can verify single request without mocking. It will be helpful in some proxy cases.

Something like that:

```python
from mockserver import MockClient, request, times

client = MockClient('localhost:1080')
client.verify_request(request(method='GET', path='/path', querystring={'test': 'test'}), timing=times(1))
```