### PR TITLE
Make the tests red again

### DIFF
--- a/test-runner.sh
+++ b/test-runner.sh
@@ -1,12 +1,6 @@
 #!/bin/bash -ex
 
-test_failed=""
-
 teardown() {
-    if [ -n "${test_failed}" ]; then
-        docker-compose logs mock-server
-    fi
-
     docker-compose down
 }
 
@@ -14,5 +8,10 @@ docker-compose up -d
 
 trap teardown INT TERM EXIT
 
-nosetests --verbose --detailed-errors --debug=DEBUG || test_failed=1
+show_failures() {
+    docker-compose logs mock-server
+    exit 1
+}
+
+nosetests --verbose --detailed-errors --debug=DEBUG || show_failures
 


### PR DESCRIPTION
Without that exit 1 tests are always green even when they fail