### PR TITLE
Stabilize tests

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --no-index --no-emit-trusted-host --output-file constraints.txt requirements.txt
 #
-certifi==2018.1.18        # via requests
+certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
-idna==2.6                 # via requests
-requests==2.18.4
-urllib3==1.22             # via requests
+idna==2.7                 # via requests
+requests==2.19.1
+urllib3==1.23             # via requests

--- a/mockserver/__init__.py
+++ b/mockserver/__init__.py
@@ -3,7 +3,7 @@ import json
 import requests
 
 
-class MockServerClient:
+class MockServerClient(object):
     def __init__(self, base_url):
         self.base_url = base_url
         self.expectations = []

--- a/test-constraints.txt
+++ b/test-constraints.txt
@@ -4,12 +4,9 @@
 #
 #    pip-compile --no-index --no-emit-trusted-host --output-file test-constraints.txt test-requirements.txt constraints.txt
 #
-certifi==2018.1.18
+certifi==2018.4.16
 chardet==3.0.4
-decorator==4.2.1          # via retry
-idna==2.6
+idna==2.7
 nose==1.3.7
-py==1.5.2                 # via retry
-requests==2.18.4
-retry==0.9.2
-urllib3==1.22
+requests==2.19.1
+urllib3==1.23

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
 nose
-retry

--- a/test-runner.sh
+++ b/test-runner.sh
@@ -1,17 +1,32 @@
 #!/bin/bash -ex
 
+get_timeout() {
+    o="timeout"
+    which gnutimeout 1>/dev/null 2>/dev/null && o="gnutimeout"
+    which gtimeout 1>/dev/null 2>/dev/null && o="gtimeout"
+    echo $o
+}
+
+show_failures() {
+    docker-compose logs --timestamps mock-server
+    exit 1
+}
+
 teardown() {
     docker-compose down
+}
+
+wait_until() {
+    local command="$1"
+
+    $(get_timeout) 10 bash -c "while true; do echo \"checking\"; ${command} && break || sleep 1; done"
 }
 
 docker-compose up -d
 
 trap teardown INT TERM EXIT
 
-show_failures() {
-    docker-compose logs mock-server
-    exit 1
-}
+wait_until "curl -XPUT http://localhost:1080/reset"
 
 nosetests --verbose --detailed-errors --debug=DEBUG || show_failures
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,13 +1,23 @@
+import time
 import unittest
+from contextlib import contextmanager
 
 from mockserver import MockServerClient
-from retry import retry
 
 MOCK_SERVER_URL = "http://localhost:1080"
 
 
 class MockServerClientTestCase(unittest.TestCase):
-    @retry(tries=10, delay=0.5)
     def setUp(self):
         self.client = MockServerClient(MOCK_SERVER_URL)
-        self.client.reset()
+
+    def tearDown(self):
+        with mock_server_breathing():
+            self.client.reset()
+
+
+@contextmanager
+def mock_server_breathing():
+    time.sleep(0.1)
+    yield
+    time.sleep(0.1)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands = ./test-runner.sh
 [testenv:lint]
 skipsdist = True
 skip_install = true
-usedevelop = False
 deps = flake8
 commands = flake8 {posargs}
 
@@ -19,10 +18,11 @@ max-line-length = 230
 include = mockserver,test
 
 [testenv:bump-dependencies]
+basepython = python3
 skipsdist = True
 skip_install = True
-usedevelop = False
-deps = pip-tools==1.11.0
+deps =
+    pip-tools==2.0.2
 commands =
     pip-compile --upgrade --no-index --no-emit-trusted-host --output-file constraints.txt requirements.txt
     pip-compile --upgrade --no-index --no-emit-trusted-host --output-file test-constraints.txt test-requirements.txt constraints.txt


### PR DESCRIPTION
By moving the reset in the teardown with some breathing we make sure
mock server has time to finish processing the requests from test
because there seem to be some race condition when verifying calls.

Since the setup doesn't do the reset anymore we need to stall until
mock server is ready to serve so the waiting was pushed in the test
runner checking with curl after the compose up is done.