### PR TITLE
Start migration to mockserver-friendly-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install mockserver-client
 
 You need a running MockServer running, see http://www.mock-server.com/mock_server/getting_started.html#start_mockserver
 
-This project's tests uses the docker image : https://github.com/internap/python-mockserver-client/blob/master/docker-compose.yml
+This project's tests uses the docker image : https://github.com/internap/python-mockserver-friendly-client/blob/master/docker-compose.yml
 
 ## Usage
 

--- a/mockserver/__init__.py
+++ b/mockserver/__init__.py
@@ -1,10 +1,16 @@
 import collections
 import json
+import warnings
+
 import requests
 
 
 class MockServerClient(object):
     def __init__(self, base_url):
+        warnings.warn("Deprecated: This library will be replaced by the official client from "
+                      "https://github.com/jamesdbloom/mockserver-client-python and will move to "
+                      "\"mockserver-friendly-client\" at https://github.com/internap/python-mockserver-friendly-client."
+                      " We are sorry for the inconvenience!", DeprecationWarning)
         self.base_url = base_url
         self.expectations = []
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mockserver-client
-url = https://github.com/internap/python-mockserver-client
+url = https://github.com/internap/python-mockserver-friendly-client
 author = INAP
 author-email = opensource@internap.com
 summary = Friendly python client to James D. Bloom's awesome MockServer


### PR DESCRIPTION
Mockserver creator is making an official client, we'll let him have the
package named "mockserver-client".

There will be a warning for a while, until he's ready to roll out, then
the package will be his.