### PR TITLE
Rename package and class to add the friendly name

### DIFF
--- a/mockserver_friendly/__init__.py
+++ b/mockserver_friendly/__init__.py
@@ -1,16 +1,11 @@
 import collections
 import json
-import warnings
 
 import requests
 
 
-class MockServerClient(object):
+class MockServerFriendlyClient(object):
     def __init__(self, base_url):
-        warnings.warn("Deprecated: This library will be replaced by the official client from "
-                      "https://github.com/jamesdbloom/mockserver-client-python and will move to "
-                      "\"mockserver-friendly-client\" at https://github.com/internap/python-mockserver-friendly-client."
-                      " We are sorry for the inconvenience!", DeprecationWarning)
         self.base_url = base_url
         self.expectations = []
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,14 +2,14 @@ import time
 import unittest
 from contextlib import contextmanager
 
-from mockserver import MockServerClient
+from mockserver_friendly import MockServerFriendlyClient
 
 MOCK_SERVER_URL = "http://localhost:1080"
 
 
 class MockServerClientTestCase(unittest.TestCase):
     def setUp(self):
-        self.client = MockServerClient(MOCK_SERVER_URL)
+        self.client = MockServerFriendlyClient(MOCK_SERVER_URL)
 
     def tearDown(self):
         with mock_server_breathing():

--- a/test/test_basic_expectations.py
+++ b/test/test_basic_expectations.py
@@ -1,5 +1,5 @@
 import requests
-from mockserver import request, response, times, seconds
+from mockserver_friendly import request, response, times, seconds
 from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 

--- a/test/test_basic_responses.py
+++ b/test/test_basic_responses.py
@@ -1,7 +1,7 @@
 import time
 
 import requests
-from mockserver import request, response, milliseconds
+from mockserver_friendly import request, response, milliseconds
 from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 

--- a/test/test_basic_stubbing.py
+++ b/test/test_basic_stubbing.py
@@ -1,6 +1,6 @@
 import time
 import requests
-from mockserver import request, response, times
+from mockserver_friendly import request, response, times
 from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 

--- a/test/test_delays.py
+++ b/test/test_delays.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mockserver import _to_delay, seconds, milliseconds, microseconds, nanoseconds, minutes, \
+from mockserver_friendly import _to_delay, seconds, milliseconds, microseconds, nanoseconds, minutes, \
     hours, days
 
 

--- a/test/test_form_requests.py
+++ b/test/test_form_requests.py
@@ -1,5 +1,5 @@
 import requests
-from mockserver import request, response, form
+from mockserver_friendly import request, response, form
 from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 

--- a/test/test_json_requests.py
+++ b/test/test_json_requests.py
@@ -1,5 +1,5 @@
 import requests
-from mockserver import request, response, times, json_equals, json_contains
+from mockserver_friendly import request, response, times, json_equals, json_contains
 from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 

--- a/test/test_json_response.py
+++ b/test/test_json_response.py
@@ -1,5 +1,5 @@
 import requests
-from mockserver import request, json_response
+from mockserver_friendly import request, json_response
 from test import MOCK_SERVER_URL, MockServerClientTestCase
 
 


### PR DESCRIPTION
Warning was also removed as this was moved.

To avoid colliding with the official mock server client that might be
coming, the package was renamed along with the class