### PR TITLE
Specify the README format for pipy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ author-email = opensource@internap.com
 summary = Friendly python client to James D. Bloom's awesome MockServer
 description-file =
     README.md
+long_description_content_type = text/markdown
 classifier =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers


### PR DESCRIPTION
Set the format to markdown because the default is rst